### PR TITLE
Prevent FileNotFoundError when removing citation folder

### DIFF
--- a/github_html_parser.py
+++ b/github_html_parser.py
@@ -20,8 +20,13 @@ for type in full_list:
 
     # Save html (div) and ascii title [ [<div></div>, "Example Title"]]
 
-    shutil.rmtree(citation_folder)
+    # Check if the folder exists before attempting to remove it to avoid FileNotFoundError
+    if os.path.exists(citation_folder):
+        shutil.rmtree(citation_folder)
+    
     os.makedirs(citation_folder)
+
+    
 
     html_array = []
 


### PR DESCRIPTION
Added a check for the existence of the citation folder before attempting to remove it.