### PR TITLE
fix: update broken external links on activities/impact page

### DIFF
--- a/activities/impact/index.html
+++ b/activities/impact/index.html
@@ -85,8 +85,8 @@
           <ul>
             <li>Boston College: <a href="http://burnsantiphoner.bc.edu/">Burns Antiphoner</a> (Diva + CANTUS display methods)</li>
             <li>Duke University Libraries: <a href="http://blogs.library.duke.edu/bitstreams/2014/06/06/leveling-up-our-document-viewer/">http://blogs.library.duke.edu/<wbr />bitstreams/2014/06/06/<wbr />leveling-up-our-document-<wbr />viewer/</a></li>
-            <li>Omas@MITH: <a href="https://github.com/umd-mith/ema/tree/master/Omas">https://github.com/umd-mith/ema/tree/master/Omas</a> (libmei + verovio)</li>
-            <li>Continuo@MITH: <a href="http://mith.us/continuo/">http://mith.us/continuo/</a> + <a href="https://github.com/umd-mith/continuo">https://github.com/umd-mith/<wbr />continuo</a> (Verovio)</li>
+            <li>Omas@MITH: <a href="https://github.com/music-addressability/ema-for-mei">https://github.com/music-addressability/ema-for-mei</a> (libmei + verovio)</li>
+            <li>Continuo@MITH: <a href="https://github.com/umd-mith/continuo">https://github.com/umd-mith/<wbr />continuo</a> (Verovio; archived project)</li>
           </ul>
           <p><br /></p>
           <p>Projects that we have contributed to:</p>


### PR DESCRIPTION
- replace the broken Omas@MITH link with the current EMA for MEI repository
- remove the unusable Continuo demo page link
- keep the archived Continuo repository as a historical reference