### PR TITLE
Issue 34 fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [SIMSSA](https://ddmal.github.io/simssa-website/)
+# [SIMSSA](https://simssa.ca/)
 
 This is the repository for the SIMSSA website distributed via GitHub Pages. It is a static website built to run without a content management system (CMS) like Jekyll. The website contents and dependency files are stored in this repository. The formatting was adapted from the Lanyon theme, developed by Mark Otto for the Jekyll site generator.
 

--- a/activities/workshops/index.html
+++ b/activities/workshops/index.html
@@ -69,6 +69,7 @@
       </div>
     </div>
     <div class="container">
+
       <div class="page-header" id="banner">
         <div class="row">
           <div class="col-lg-12">
@@ -478,7 +479,7 @@
                   <div class="col-lg-12">
                     <h2>Workshop on SIMSSA VIII</h2>
                     <h4 class="event">                    CIRMMT, McGill University,                    Montreal, QC,                  May 21, 2016                </h4>
-                    <p>This is the eighth in the series of SIMSSA Workshops, highlighting recent developments in the SIMSSA and Cantus Ultimus Projects. The workshop took place after the <a href="http://music-encoding.org/community/conference/">Music Encoding Conference</a>, hosted at McGill University.</p>
+                    <p>This is the eighth in the series of SIMSSA Workshops, highlighting recent developments in the SIMSSA and Cantus Ultimus Projects. The workshop took place after the <a href="http://music-encoding.org/conference/">Music Encoding Conference</a>, hosted at McGill University.</p>
                     <p>Guests included:</p>
                     <ul>
                       <li>Ryan Bannon, Schulich School of Music, McGill University</li>
@@ -510,7 +511,7 @@
                   <div class="col-lg-12">
                     <h2>Workshop on SIMSSA VII</h2>
                     <h4 class="event">                    MedRen,                    Brussels, Belgium,                  July 08, 2015                </h4>
-                    <p>SIMSSA Workshop VII took place at <a href="http://medren2015.ulb.ac.be/">MedRen</a> in Brussels. Ichiro Fujinaga introduced the workshop and gave some recent updates. Julie Cumming and Andrew Hankinson gave updates on the Analysis and Content axes, and Laurent Pugin discussed Verovio. For more details, please check out our <a href="https://simssa.ca/blog/simssa-summer-conferences-new-york-and-brussels/" title="SIMSSA Summer Conferences">blog post</a>.</p>
+                    <p>SIMSSA Workshop VII took place at MedRen in Brussels. Ichiro Fujinaga introduced the workshop and gave some recent updates. Julie Cumming and Andrew Hankinson gave updates on the Analysis and Content axes, and Laurent Pugin discussed Verovio. For more details, please check out our <a href="https://simssa.ca/blog/simssa-summer-conferences-new-york-and-brussels/" title="SIMSSA Summer Conferences">blog post</a>.</p>
                     <p><img src="https://simssa.ca/assets/img/MedRenWorkshop-20150820113127.png" alt="MedRen Workshop VII" /></p>
                     <p>Guests included:</p>
                     <ul>
@@ -583,7 +584,7 @@
                   <div class="col-lg-12">
                     <h2>Workshop on SIMSSA IV: ONRP and Cantus Ultimus</h2>
                     <h4 class="event">                    CIRMMT, McGill University,                    Montreal, QC,                  September 29, 2014                </h4>
-                    <p><a href="http://www.cirmmt.org/activities/workshops/research/simssa0914/event">Workshop on SIMSSA (Single Interface for Music Score Searching and Analysis) IV</a></p>
+                    <p><a href="https://www.cirmmt.org/en/events/workshops/meetings/simssa0914">Workshop on SIMSSA (Single Interface for Music Score Searching and Analysis) IV</a></p>
                     <p>Highlighted recent development in the SIMSSA project and the ELVIS (Electronic Locator of Vertical Interval Successions) project. Included presentations by guests from two other SSHRC projects: Optical Neume Recognition project and Cantus Ultimus project. For more details, please check out our <a href="https://simssa.ca/blog/simssa-workshop-iva/" title="SIMSSA IV blog">blog post</a>.</p>
                     <p><img src="https://simssa.ca/assets/img/SIMSSA_4_Group_Photo1-20150121092558.jpg" alt="The people who came to SIMSSA IV on Sept. 29, 2014." /></p>
                     <p>Guests included:</p>
@@ -760,7 +761,7 @@
                   <div class="col-lg-12">
                     <h2>Workshop on SIMSSA II</h2>
                     <h4 class="event">                    CIRMMT, McGill University,                    Montreal, QC,                  July 28, 2012                </h4>
-                    <p><a href="http://www.cirmmt.org/activities/workshops/research/simssa/event">“Workshop on SIMSSA: Single Interface for Music Score Searching and Analysis II</a>” organized by CIRMMT Research Axis 3. For more details, please check out our <a href="https://simssa.ca/blog/simssa-workshop-overview-july-28th-2012/" title="SIMSSA II blog">blog post</a>.</p>
+                    <p><a href="https://www.cirmmt.org/en/events/workshops/meetings/simssa">“Workshop on SIMSSA: Single Interface for Music Score Searching and Analysis II</a>” organized by CIRMMT Research Axis 3. For more details, please check out our <a href="https://simssa.ca/blog/simssa-workshop-overview-july-28th-2012/" title="SIMSSA II blog">blog post</a>.</p>
                     <p><img src="https://simssa.ca/assets/img/IAML_Group_Photo.jpg" alt="" /></p>
                     <p>Keynote speaker:</p>
                     <ul>
@@ -786,7 +787,7 @@
                   <div class="col-lg-12">
                     <h2>CIRMMT Workshop: Processing Large  Amounts of Musical Information</h2>
                     <h4 class="event">                    CIRMMT, McGill University,                    Montreal, QC,                  February 17, 2012                </h4>
-                    <p><a href="http://www.cirmmt.org/activities/workshops/research/musical-info/event">Workshop on processing large amounts of musical information</a> organized by CIRMMT Research Axis 3. For more details, please check out our <a href="https://simssa.ca/blog/elvis-and-ra3-host-a-mini-conference/" title="CIRMMT mini-conference blog">blog post</a>.</p>
+                    <p><a href="https://www.cirmmt.org/en/events/workshops/meetings/musical-info">Workshop on processing large amounts of musical information</a> organized by CIRMMT Research Axis 3. For more details, please check out our <a href="https://simssa.ca/blog/elvis-and-ra3-host-a-mini-conference/" title="CIRMMT mini-conference blog">blog post</a>.</p>
                     <p>Speakers including:</p>
                     <ul>
                       <li>Thierry Bertin-Mahieux, School of Engineering and Applied Science, Columbia University</li>
@@ -818,7 +819,7 @@
                   <div class="col-lg-12">
                     <h2>Cantus Ultimus Workshop</h2>
                     <h4 class="event">                    CIRMMT, McGill University,                    Montreal, QC,                  September 08, 2012                </h4>
-                    <p><a href="http://www.cirmmt.org/activities/workshops/research/ra3120908/event">Cantus Ultimus Workshop: Building the ideal digital music library for plainchant.</a>
+                    <p><a href="https://www.cirmmt.org/en/events/workshops/meetings/ra3120908">Cantus Ultimus Workshop: Building the ideal digital music library for plainchant.</a>
                       Explored the potential applications of SIMSSA (Single Interface for Music Score Searching and Analysis) technologies developed at CIRMMT for enhancing the <em>Cantus</em> database, especially towards implementing full-music search of plainchant manuscripts.
                     </p>
                     <p>Guests included:</p>


### PR DESCRIPTION
## Summary
- update the SIMSSA link in `README.md`
- update outdated links on the workshops page
- replace moved CIRMMT event URLs with their current locations
- remove or avoid links that no longer lead to usable public pages
